### PR TITLE
fix mysqli_get_client_version() should have no args in PHP 8

### DIFF
--- a/src/Components/Database/Conf.php
+++ b/src/Components/Database/Conf.php
@@ -23,7 +23,7 @@ class Conf extends DatabaseConstants
         $conf[$this->ID] = array(
             'sqlite3'             => $sqlite3Version ? $sqlite3Version['versionString'] : false,
             'sqliteLibversion'    => \function_exists('\\sqlite_libversion') ? \sqlite_libversion() : false,
-            'mysqliClientVersion' => \function_exists('\\mysqli_get_client_version') ? \mysqli_get_client_version(null) : false,
+            'mysqliClientVersion' => \function_exists('\\mysqli_get_client_version') ? \mysqli_get_client_version() : false,
             'mongo'               => \class_exists('\\Mongo'),
             'mongoDb'             => \class_exists('\\MongoDB'),
             'postgreSql'          => \function_exists('\\pg_connect'),


### PR DESCRIPTION
With PHP 8.0.0RC2,

```
<br />
--
  | <b>Fatal error</b>:  Uncaught ArgumentCountError: mysqli_get_client_version() expects exactly 0 arguments, 1 given in prober.php:24
  | Stack trace:
  | #0 prober.php(24): mysqli_get_client_version(NULL)
  | #1 prober.php(2): InnStudio\Prober\Components\Database\Conf-&gt;conf(Array, Array)
  | #2 prober.php(5): InnStudio\Prober\Components\Events\EventsApi::emit('conf', Array)
  | #3 prober.php(5): InnStudio\Prober\Components\Bootstrap\Render-&gt;__construct()
  | #4 prober.php(24): InnStudio\Prober\Components\Bootstrap\Bootstrap-&gt;__construct()
  | #5 {main}
  | thrown in <b>prober.php</b> on line <b>24</b><br />

```


According to the ["Example #1" in the official PHP document](https://www.php.net/manual/en/mysqli.get-client-version.php#refsect1-mysqli.get-client-version-examples), we don't need an argument for `mysqli_get_client_version()`.

---

Patch has been tested in PHP 5.4, 5.6, 7.2, 7.4, 8.0.0RC2.

---

By the way, could you kindly add a [`hacktoberfest-accepted`](https://hacktoberfest.digitalocean.com/hacktoberfest-update) label to this PR if this PR is accepted?